### PR TITLE
nghttp2: 1.17.0 -> 1.19.0

### DIFF
--- a/pkgs/development/libraries/nghttp2/default.nix
+++ b/pkgs/development/libraries/nghttp2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgconfig
 
 # Optional Dependencies
-, openssl ? null, libev ? null, zlib ? null
+, openssl ? null, libev ? null, zlib ? null, libcares ? null
 , enableHpack ? false, jansson ? null
 , enableAsioLib ? false, boost ? null
 , enableGetAssets ? false, libxml2 ? null
@@ -17,18 +17,18 @@ with { inherit (stdenv.lib) optional; };
 
 stdenv.mkDerivation rec {
   name = "nghttp2-${version}";
-  version = "1.17.0";
+  version = "1.19.0";
 
   # Don't use fetchFromGitHub since this needs a bootstrap curl
   src = fetchurl {
     url = "https://github.com/nghttp2/nghttp2/releases/download/v${version}/nghttp2-${version}.tar.bz2";
-    sha256 = "7685b6717d205d3a251b7dd5e73a7ca5e643bc5c01f928b82bfeed30c243f28a";
+    sha256 = "477466eee27158d37b4478d9335dd091497cae4d7f2375fc6657beab67db9e7a";
   };
 
   outputs = [ "out" "dev" "lib" ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl libev zlib ]
+  buildInputs = [ openssl libev zlib libcares ]
     ++ optional enableHpack jansson
     ++ optional enableAsioLib boost
     ++ optional enableGetAssets libxml2


### PR DESCRIPTION
Package update.
New features as documented in changelogs : https://github.com/nghttp2/nghttp2/releases

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Builds and runs successfully on NixOS-16.09 :
- with OpenSSL 1.0.2k
- with OpenSSL 1.1.0d
- running kernel 4.4.47 or running kernel 4.8.17-grsec
