### PR TITLE
rng-tools improvements

### DIFF
--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, libtool, autoreconfHook, pkgconfig
 , sysfsutils
+, argp-standalone
   # WARNING: DO NOT USE BEACON GENERATED VALUES AS SECRET CRYPTOGRAPHIC KEYS
   # https://www.nist.gov/programs-projects/nist-randomness-beacon
 , curl ? null, libxml2 ? null, openssl ? null, withNistBeacon ? false
@@ -15,18 +16,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "rng-tools";
-  version = "6.7";
+  version = "6.8";
 
   src = fetchFromGitHub {
     owner = "nhorman";
     repo = "rng-tools";
     rev = "v${version}";
-    sha256 = "19f75m6mzg8h7b4snzg7d6ypvkz6nq32lrpi9ja95gqz4wsd18a5";
+    sha256 = "1clm9i9xg3j79q0d6vinn6dx0nwh1fvzcmkqpcbay7mwsgkknvw2";
   };
 
   postPatch = ''
-    cp README.md README
-
     ${optionalString withPkcs11 ''
       substituteInPlace rngd.c \
         --replace /usr/lib64/opensc-pkcs11.so ${opensc}/lib/opensc-pkcs11.so
@@ -42,19 +41,21 @@ stdenv.mkDerivation rec {
     (withFeature   withPkcs11        "pkcs11")
   ];
 
+  # argp-standalone is only used when libc lacks argp parsing (musl)
   buildInputs = [ sysfsutils ]
+    ++ optionals stdenv.hostPlatform.isx86_64 [ argp-standalone ]
     ++ optionals withGcrypt        [ libgcrypt ]
     ++ optionals withJitterEntropy [ jitterentropy ]
     ++ optionals withNistBeacon    [ curl libxml2 openssl ]
     ++ optionals withPkcs11        [ libp11 openssl ];
 
-  # This shouldn't be necessary but is as of 6.7
-  NIX_LDFLAGS = optionalString withPkcs11 "-lcrypto";
-
   enableParallelBuilding = true;
 
   # For cross-compilation
   makeFlags = [ "AR:=$(AR)" ];
+
+  doCheck = true;
+  preCheck = "patchShebangs tests/*.sh";
 
   meta = {
     description = "A random number generator daemon";

--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -6,9 +6,7 @@
 , curl ? null, libxml2 ? null, openssl ? null, withNistBeacon ? false
   # Systems that support RDRAND but not AES-NI require libgcrypt to use RDRAND as an entropy source
 , libgcrypt ? null, withGcrypt ? true
-  # Not sure if jitterentropy is safe to use for cryptography
-  # and thus a default entropy source
-, jitterentropy ? null, withJitterEntropy ? false
+, jitterentropy ? null, withJitterEntropy ? true
 , libp11 ? null, opensc ? null, withPkcs11 ? true
 }:
 
@@ -36,7 +34,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     (withFeature   withGcrypt        "libgcrypt")
-    (enableFeature withJitterEntropy "jitterentropy")
+    (withFeature   withJitterEntropy "jitterentropy")
     (withFeature   withNistBeacon    "nistbeacon")
     (withFeature   withPkcs11        "pkcs11")
   ];


### PR DESCRIPTION
###### Motivation for this change
includes jitterentropy by default

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @c0bw3b 
